### PR TITLE
any() `self.^parent` instead of looping

### DIFF
--- a/lib/ClassX/StrictConstructor.pm
+++ b/lib/ClassX/StrictConstructor.pm
@@ -21,10 +21,7 @@ role ClassX::StrictConstructor {
         my @extras;
         for %attrs.keys -> $attr {
             unless has_attr(self.WHAT, $attr) {
-                my $inherited = False;
-                for self.^parents -> $parent {
-                    $inherited = True if has_attr($parent, $attr)
-                }
+                my $inherited = has_attr(any(self.^parents), $attr);
                 @extras.push: $attr unless $inherited;
             }
         }


### PR DESCRIPTION
Also allows for early breakage out of the loop (`last` as soon as one matched)

Note: I'm not sure if "so" here would help improve the performances?
