### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/t-basic.t
+++ b/t/t-basic.t
@@ -32,21 +32,21 @@ class Tricky does ClassX::StrictConstructor {
     }
 }
 
-lives_ok { Standard.new(thing => 1, bad => 99) }, 'standard class ignores unknown arguments';
-throws_like { Stricter.new(thing => 1, bad => 99) }, X::UnknownAttribute;
-lives_ok { Subclass.new(thing => 1, size => 'large') },
+lives-ok { Standard.new(thing => 1, bad => 99) }, 'standard class ignores unknown arguments';
+throws-like { Stricter.new(thing => 1, bad => 99) }, X::UnknownAttribute;
+lives-ok { Subclass.new(thing => 1, size => 'large') },
          'subclass constructor handles known attributes correctly';
-throws_like { Subclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
-lives_ok { StrictSubclass.new(thing => 1, size => 'large') },
+throws-like { Subclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
+lives-ok { StrictSubclass.new(thing => 1, size => 'large') },
          "subclass that doesn't use strict correctly recognizes bad attribute";
-throws_like { StrictSubclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
-lives_ok { OtherStrictSubclass.new(thing => 1, size => 'large') },
+throws-like { StrictSubclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
+lives-ok { OtherStrictSubclass.new(thing => 1, size => 'large') },
          "strict subclass from parent that doesn't use strict constructor handles known "
          ~ "attributes correctly";
-throws_like { OtherStrictSubclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
-lives_ok { Tricky.new(thing => 1, spy => 99) },
+throws-like { OtherStrictSubclass.new(thing => 1, bad => 99) }, X::UnknownAttribute;
+lives-ok { Tricky.new(thing => 1, spy => 99) },
          'can work around strict constructor by deleting params in new()';
-throws_like { Tricky.new(thing => 1, agent => 99) }, X::UnknownAttribute;
+throws-like { Tricky.new(thing => 1, agent => 99) }, X::UnknownAttribute;
 
 # MooseX::StrictConstructor InitArg tests are not here, because nothing like init_arg
 # exists in Perl 6


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.